### PR TITLE
Keep rendering even though there is an error

### DIFF
--- a/client/src/error-boundaries/application-error-boundary.js
+++ b/client/src/error-boundaries/application-error-boundary.js
@@ -20,15 +20,17 @@ export class ApplicationErrorBoundary extends React.Component {
     // TODO: Report this error to Sentry, https://github.com/mdn/stumptown-renderer/issues/99
   }
   render() {
-    if (this.state.error) {
-      return (
-        <div className="application-error-boundary">
-          Unfortunately, this application has encountered unhandled error and
-          the content cannot be shown.
-          {/* TODO: When error reporting is set up, the message should include "We have been notified of this error" or something similar */}
-        </div>
-      );
-    }
-    return this.props.children;
+    return (
+      <>
+        {this.state.error ? (
+          <div className="application-error-boundary">
+            Unfortunately, this application has encountered unhandled error and
+            the content cannot be shown.
+            {/* TODO: When error reporting is set up, the message should include "We have been notified of this error" or something similar */}
+          </div>
+        ) : null}
+        {this.props.children}
+      </>
+    );
   }
 }

--- a/client/src/ingredients/browser-compatibility-table/index.js
+++ b/client/src/ingredients/browser-compatibility-table/index.js
@@ -29,8 +29,15 @@ export class BrowserCompatibilityTable extends Component {
     hasFlag: false,
     hasPrefix: false,
     hasNotes: false,
-    legendSet: false
+    legendSet: false,
+    crash: false
   };
+
+  componentDidMount() {
+    this.setState({
+      crash: true
+    });
+  }
 
   gatherPlatformsAndBrowsers(category) {
     let platforms = ["desktop", "mobile"];
@@ -84,6 +91,11 @@ export class BrowserCompatibilityTable extends Component {
       throw new Error(
         "BrowserCompatibilityTable component called with empty data"
       );
+    }
+
+    if (this.state.crash) {
+      // This will crash only in browser
+      throw new Error("I'm crashing");
     }
 
     const [platforms, displayBrowsers] = this.gatherPlatformsAndBrowsers(


### PR DESCRIPTION
In response to https://github.com/mdn/stumptown-renderer/pull/172#issuecomment-539590251

This draft PR tries to illustrate @peterbe's situation:

1. The HTML file is loaded fine.
2. But after a while, the application crashes

So this draft PR keeps rendering the "crashed" application, while showing an error banner.

To achieve that,

1. I set `client/src/ingredients/browser-compatibility-table\index.js` to crash only in browser (by setting a state at `componentDidMount`, which is only called in non-SSR).
2. I run production build (`yarn deployment-build`), which generated all HTMLs succesfully
3. I run a [local static web server](https://www.npmjs.com/package/http-server) in `client/build`

and I got this:

![Annotation 2019-10-09 214650](https://user-images.githubusercontent.com/3090380/66487763-77cc6000-eadf-11e9-98f6-b9bd35fd227a.png)

Apparently, this approach does not work, because

1. The application keeps "crashing" (Application Error Boundary's `componentDidCatch` kept being called) because the crashed component is kept being rendered, even though it has thrown error.
2. This, in turn, causes the application unusable, because there is nothing useful rendered.
3. To make the application useful, we need to "rollback" to the initial HTML codes before the JS codes run, but at this point, it's already too late.

You can try play around in this branch to understand what I mean.

Please let me know if you have any suggestions.

Thanks!
